### PR TITLE
String replacement to handle paths with spaces

### DIFF
--- a/lua/vale/cmd.lua
+++ b/lua/vale/cmd.lua
@@ -7,7 +7,7 @@ function cmd.build()
     config.get_bin(),
     "--output=line",
     "--config=" .. config.get_vale_config_path(),
-    vim.api.nvim_buf_get_name(0),
+    string.format('"%s"', vim.api.nvim_buf_get_name(0)),
   }, " ")
 end
 


### PR DESCRIPTION
Ran into an issue running against a path that included spaces. This changed fixed it right up for me. 